### PR TITLE
Bump v0.1.13 policy version.

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,27 +4,27 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.12
+version: 0.1.13
 name: safe-labels
 displayName: Safe Labels
-createdAt: 2023-03-30T16:34:19.945383359Z
+createdAt: 2023-07-07T18:45:46.064822442Z
 description: A policy that validates Kubernetes' resource labels
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/safe-labels-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/safe-labels:v0.1.12
+  image: ghcr.io/kubewarden/policies/safe-labels:v0.1.13
 keywords:
 - labels
 links:
 - name: policy
-  url: https://github.com/kubewarden/safe-labels-policy/releases/download/v0.1.12/policy.wasm
+  url: https://github.com/kubewarden/safe-labels-policy/releases/download/v0.1.13/policy.wasm
 - name: source
   url: https://github.com/kubewarden/safe-labels-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/safe-labels:v0.1.12
+  kwctl pull ghcr.io/kubewarden/policies/safe-labels:v0.1.13
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.13 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.1.13

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
