### PR TITLE
ci: bump github-actions to v3.1.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@v3.1.5
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@v3.1.6
 
   release:
     needs: test
@@ -23,6 +23,6 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go.yml@v3.1.5
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go.yml@v3.1.6
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/policies/safe-labels

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,4 +3,4 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@v3.1.5
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@v3.1.6


### PR DESCRIPTION
## Description

Bumps github-actions to v3.1.6, fixing the failing release CI which was using tinygo `0.27.0`.

## Test
tested in fork



