### PR TITLE
chore(deps): tinygo v0.39.0 update.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ policy.wasm: $(SOURCE_FILES) go.mod go.sum
 		--rm \
 		-e GOFLAGS="-buildvcs=false" \
 		-v ${PWD}:/src \
-		-w /src tinygo/tinygo:0.37.0 \
+		-w /src tinygo/tinygo:0.39.0 \
 		tinygo build -o policy.wasm -target=wasi -no-debug .
 
 


### PR DESCRIPTION
To be possible to update the golang version to v1.25 it's necessary to bump the Tinygo version to v0.39.0.

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #XXX

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
